### PR TITLE
Remove dependency on libraries module.

### DIFF
--- a/leaflet.info
+++ b/leaflet.info
@@ -5,6 +5,5 @@ backdrop = 1.x
 type = module
 
 dependencies[] = image
-dependencies[] = libraries
 
 files[] = leaflet.formatters.inc


### PR DESCRIPTION
Looks like all the necessary changes have been made to support core library functionality in Backdrop.

https://backdropcms.org/project/libraries

https://github.com/backdrop-contrib/leaflet/commit/f7b8cee373ffbdfeb865703c03df56cb3a8a556a#diff-a95cc789b5fe98e3c30c56120375cd19