### PR TITLE
Fixes #10: Applying to become co-maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Current Maintainers
 
 - Wes Jones (https://github.com/earthday47)
 - gifad (https://github.com/gifad)
+- Indigoxela (https://github.com/indigoxela)
 
 Credits
 -------


### PR DESCRIPTION
Following the Backdrop contrib guidelines for co-maintainership. 