### PR TITLE
Remove gifad from current maintainer, and update their credits link

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,11 @@ Current Maintainers
 -------------------
 
 - Wes Jones (https://github.com/earthday47)
-- gifad (https://github.com/gifad)
 - Indigoxela (https://github.com/indigoxela)
 
 Credits
 -------
 
-- Ported to Backdrop CMS by gifad (https://github.com/gifad)
+- Ported to Backdrop CMS by gifad (https://www.drupal.org/u/gifad)
 - Originally written for Drupal by [levelos](http://drupal.org/user/54135) and 
   [pvhee](http://drupal.org/user/108811)


### PR DESCRIPTION
As per the Zulip discussion, https://github.com/gifad is not a valid GitHub account any more.